### PR TITLE
Feature/kataoka/create migration files

### DIFF
--- a/src/database/migrations/2022_02_13_040308_create_product_masters_table.php
+++ b/src/database/migrations/2022_02_13_040308_create_product_masters_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProductMastersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('product_masters', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('product_name');
+            $table->string('image');
+            $table->integer('price');
+            $table->dateTime('sales_start_time');
+            $table->dateTime('sales_end_time');
+            $table->integer('display_order');
+            $table->dateTime('registration_time');
+            $table->dateTime('update_time');
+            $table->timestamps();
+
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('product_masters');
+    }
+}

--- a/src/database/migrations/2022_02_13_040427_create_stocks_table.php
+++ b/src/database/migrations/2022_02_13_040427_create_stocks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateStocksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('stocks', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('product_id');
+            $table->foreign('product_id')->references('id')->on('product_masters')->onDelete('cascade');
+            $table->integer('stock');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('stocks');
+    }
+}

--- a/src/database/migrations/2022_02_13_040508_create_sales_log_table.php
+++ b/src/database/migrations/2022_02_13_040508_create_sales_log_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSalesLogTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sales_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('product_id');
+            $table->foreign('product_id')->references('id')->on('product_masters')->onDelete('cascade');
+            $table->integer('purchase_price');
+            $table->dateTime('purchase_time');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sales_log');
+    }
+}


### PR DESCRIPTION
# 変更目的

- テーブル定義書の仕様を満たすため、マイグレーションファイルを作成

# 変更結果

- マイグレーション実行時及びロールバック時のエラー発生なし

# 変更内容

- 2022_02_13_create_product_masters_table.php

　　テーブル定義書の商品マスタの項目を基に、マイグレーションファイルを作成



- 2022_02_13_create_stocks_table.php

　　テーブル定義書の在庫の項目を基に、マイグレーションファイルを作成

　　product_mastersテーブルのidを外部キーとする


- 2022_02_13_create_sales_log_table.php

　　テーブル定義書売上ログの項目を基に、マイグレーションファイルを作成

　　product_mastersテーブルのidを外部キーとする