### PR TITLE
[create]商品マスタテーブルのリネーム用ファイルを作成

### DIFF
--- a/src/database/migrations/2022_02_16_133517_rename_product_masters_to_product_master_table.php
+++ b/src/database/migrations/2022_02_16_133517_rename_product_masters_to_product_master_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameProductMastersToProductMasterTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::rename('product_masters', 'product_master');
+    }
+    
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::rename('product_master','product_masters');
+    }
+}


### PR DESCRIPTION
# 変更目的

- 商品マスタテーブルのファイル名が、英語表記として不適切だったため

# 変更結果

- マイグレーション実行時及びロールバック時のエラー発生なし
- クライアントツール（Sequel Ace)にて、ファイル名が変更されていることが確認できた

![Untitled](https://user-images.githubusercontent.com/79346029/154280131-7f42b903-5cd4-4322-a40d-ecd08b5eab97.png)

# 変更内容

- 2022_02_16_133517_rename_product_masters_to_product_master_table.php

　└商品マスタテーブルのテーブル名を変更するため、リネーム用のファイルを作成