### PR TITLE
feature/Kataoka/create_migration_files

### DIFF
--- a/src/database/migrations/2022_02_19_134719_change_image_string_to_long_text_on_product_master_table.php
+++ b/src/database/migrations/2022_02_19_134719_change_image_string_to_long_text_on_product_master_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeImageStringToLongTextOnProductMasterTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('product_master', function (Blueprint $table) {
+            $table->longText('image')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('product_master', function (Blueprint $table) {
+            $table->string('image')->change();
+        });
+    }
+}


### PR DESCRIPTION
# 変更目的

- 商品マスタテーブルのimageカラムのデータ型が不適切だったため

　└画像ファイルをbase64形式に変換するため、string型では最大サイズが足りない

# 変更結果

- マイグレーション実行時及びロールバック時のエラー発生なし
- クライアントツール（Sequel Ace)にて、データ型がlongText型に変更されていることが確認できた

![image](https://user-images.githubusercontent.com/79346029/154805891-973ca008-904b-441b-996d-7687ee279b46.png)

# 変更内容

- 2022_02_19_134719_change_image_string_to_long_text_on_product_master_table.php

　└商品マスタテーブルのimageカラムのデータ型を変更するため、変更用のマイグレーションファイルを作成