### PR TITLE
Feature/kataoka/create seeder files

### DIFF
--- a/src/database/seeds/DatabaseSeeder.php
+++ b/src/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(ProductMasterTableSeeder::class);
+        $this->call(StocksTableSeeder::class);
+        $this->call(SalesLogTableSeeder::class);
     }
 }

--- a/src/database/seeds/ProductMasterTableSeeder.php
+++ b/src/database/seeds/ProductMasterTableSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class ProductMasterTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $param = [
+            'product_name' => 'コーラ',
+            'image' => base64_encode(Storage::get('cola.jpg')),
+            'price' => 100,
+            'display_order' => 1,
+        ];
+        DB::table('product_master')->insert($param);
+        $param = [
+            'product_name' => 'ビール',
+            'image' => base64_encode(Storage::get('beer.jpg')),
+            'price' => 210,
+            'display_order' => 2,
+        ];
+        DB::table('product_master')->insert($param);
+        $param = [
+            'product_name' => '食パン',
+            'image' => base64_encode(Storage::get('plain_blead.jpg')),
+            'price' => 1900,
+            'display_order' => 3,
+        ];
+        DB::table('product_master')->insert($param);
+    }
+}

--- a/src/database/seeds/SalesLogTableSeeder.php
+++ b/src/database/seeds/SalesLogTableSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class SalesLogTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $param = [
+            'product_id' => 1,
+            'purchase_price' => 200,
+        ];
+        DB::table('sales_log')->insert($param);
+        $param = [
+            'product_id' => 2,
+            'purchase_price' => 420,
+        ];
+        DB::table('sales_log')->insert($param);
+        $param = [
+            'product_id' => 3,
+            'purchase_price' => 3800,
+        ];
+        DB::table('sales_log')->insert($param);
+    }
+}

--- a/src/database/seeds/StocksTableSeeder.php
+++ b/src/database/seeds/StocksTableSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class StocksTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $param = [
+            'product_id' => 1,
+            'stock' => 2,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_id' => 2,
+            'stock' => 3,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_id' => 3,
+            'stock' => 4,
+        ];
+        DB::table('stocks')->insert($param);
+    }
+}


### PR DESCRIPTION
# 変更目的

- シーダーファイルを作成し、テストデータをデータベース上に作成可能な状態にするため

# 変更結果

- シーディング実行時のエラー発生なし
- クライアントツール（Sequel Ace)にて、想定通りのテストデータが作成されていることが確認できた

![Untitled (1)](https://user-images.githubusercontent.com/79346029/155265051-8aeda474-8660-405e-b5e2-a60a6c6b99f8.png)
![Untitled (2)](https://user-images.githubusercontent.com/79346029/155265064-67531ff3-9ead-4d70-a80c-7f964f87cb66.png)
![Untitled (3)](https://user-images.githubusercontent.com/79346029/155265078-39c18351-bea1-4df4-abd0-f35297e76f34.png)


# 変更内容

- ProductMasterTableSeeder.php

　└製品マスタテーブルのシーダーファイルを作成

　└コーラ・ビール・食パンの３種類のデータを登録

- SalesLogTableSeeder.php

　└売上ログテーブルのシーダーファイルを作成

- StocksTableSeeder.php

　└在庫テーブルのシーダーファイルを作成