### PR TITLE
Feature/kataoka/create migration files

### DIFF
--- a/src/database/migrations/2022_02_13_040308_create_product_masters_table.php
+++ b/src/database/migrations/2022_02_13_040308_create_product_masters_table.php
@@ -18,11 +18,11 @@ class CreateProductMastersTable extends Migration
             $table->string('product_name');
             $table->string('image');
             $table->integer('price');
-            $table->dateTime('sales_start_time');
-            $table->dateTime('sales_end_time');
+            $table->dateTime('sales_start_time')->nullable();
+            $table->dateTime('sales_end_time')->nullable();
             $table->integer('display_order');
-            $table->dateTime('registration_time');
-            $table->dateTime('update_time');
+            $table->dateTime('registration_time')->nullable();
+            $table->dateTime('update_time')->nullable();
             $table->timestamps();
 
             $table->softDeletes();

--- a/src/database/migrations/2022_02_13_040508_create_sales_log_table.php
+++ b/src/database/migrations/2022_02_13_040508_create_sales_log_table.php
@@ -18,7 +18,7 @@ class CreateSalesLogTable extends Migration
             $table->unsignedBigInteger('product_id');
             $table->foreign('product_id')->references('id')->on('product_masters')->onDelete('cascade');
             $table->integer('purchase_price');
-            $table->dateTime('purchase_time');
+            $table->dateTime('purchase_time')->nullable();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
# 変更目的

- dateTime型のカラムについて、null入力が不可となっており、シーディング実行時にエラーが発生したため

# 変更結果

- マイグレーション実行時及びロールバック時のエラー発生なし
- シーディング実行時のエラー発生無し

# 変更内容

- 2022_02_13_040308_create_product_masters_table.php

　└dateTime型のカラムについて、null入力可となるように追記した

- 2022_02_13_040508_create_sales_log_table.php

　└dateTime型のカラムについて、null入力可となるように追記した