### PR TITLE
[create]カラム削除用ファイルを作成

### DIFF
--- a/src/database/migrations/2022_03_03_115935_drop_column_product_masters_table.php
+++ b/src/database/migrations/2022_03_03_115935_drop_column_product_masters_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DropColumnProductMastersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('product_masters', function (Blueprint $table) {
+            $table->dropColumn('registration_time');
+            $table->dropColumn('update_time');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('product_masters', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
# 変更目的

- デフォルトでtimestampsカラムが用意されているにもかかわらず、役割が重複するカラムを作成していたため

# 変更結果

- マイグレーション実行時及びロールバック時のエラー発生なし
- 想定通りにカラムが削除されていることが確認できた

![image](https://user-images.githubusercontent.com/79346029/156664652-46770cb6-962f-408e-8933-8dd2dd63e6f0.png)


![image](https://user-images.githubusercontent.com/79346029/156664458-b9e2b3be-e573-49cd-bf9f-6ad3cc8f445d.png)

# 変更内容

- 2022_03_03_115935_drop_column_product_masters_table.php

　└製品マスタテーブルについて、登録日時と更新日時のカラムを削除

　（Laravelのデフォルトで用意されているため、不要）