### PR TITLE
[create]カラム名変更用ファイルを作成

### DIFF
--- a/src/database/migrations/2022_04_11_225421_rename_product_id_to_product_master_id_on_stocks_table.php
+++ b/src/database/migrations/2022_04_11_225421_rename_product_id_to_product_master_id_on_stocks_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameProductIdToProductMasterIdOnStocksTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('stocks', function (Blueprint $table) {
+            $table->renameColumn('product_id', 'product_master_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('stocks', function (Blueprint $table) {
+            $table->renameColumn('product_master_id', 'product_id');
+        });
+    }
+}


### PR DESCRIPTION
# 変更目的

- 製品マスタテーブルと在庫テーブルのリレーションを行うにあたり、在庫テーブルの外部キー名が命名規則に則っていない形になっていたため、修正

# 変更結果

- マイグレーション実行時及びロールバック時のエラー発生なし
- 想定通りにカラムが削除されていることが確認できた

![スクリーンショット 2022-04-11 午後9 35 24](https://user-images.githubusercontent.com/79346029/163182159-09d0c85c-7780-4fc8-b4e9-d5188571be86.jpg)

![スクリーンショット 2022-04-11 午後9 39 59](https://user-images.githubusercontent.com/79346029/163182228-609808c3-60bd-4a16-88d5-e0d3166557d0.jpg)



# 変更内容

- 2022_03_03_115935_drop_column_product_masters_table.php

　└外部キー名をproduct_id→product_master_idに変更