### PR TITLE
[update]配列の要素名を修正

### DIFF
--- a/src/database/seeds/SalesLogsTableSeeder.php
+++ b/src/database/seeds/SalesLogsTableSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Carbon\Carbon;
 
 class SalesLogsTableSeeder extends Seeder
 {
@@ -12,18 +13,21 @@ class SalesLogsTableSeeder extends Seeder
     public function run()
     {
         $param = [
-            'product_id' => 1,
+            'product_master_id' => 1,
             'purchase_price' => 200,
+            'purchase_time' => Carbon::now(),
         ];
         DB::table('sales_logs')->insert($param);
         $param = [
-            'product_id' => 2,
+            'product_master_id' => 2,
             'purchase_price' => 420,
+            'purchase_time' => Carbon::now(),
         ];
         DB::table('sales_logs')->insert($param);
         $param = [
-            'product_id' => 3,
+            'product_master_id' => 3,
             'purchase_price' => 3800,
+            'purchase_time' => Carbon::now(),
         ];
         DB::table('sales_logs')->insert($param);
     }

--- a/src/database/seeds/StocksTableSeeder.php
+++ b/src/database/seeds/StocksTableSeeder.php
@@ -12,17 +12,17 @@ class StocksTableSeeder extends Seeder
     public function run()
     {
         $param = [
-            'product_id' => 1,
+            'product_master_id' => 1,
             'stock' => 2,
         ];
         DB::table('stocks')->insert($param);
         $param = [
-            'product_id' => 2,
+            'product_master_id' => 2,
             'stock' => 3,
         ];
         DB::table('stocks')->insert($param);
         $param = [
-            'product_id' => 3,
+            'product_master_id' => 3,
             'stock' => 4,
         ];
         DB::table('stocks')->insert($param);


### PR DESCRIPTION
# 変更目的

- `ProductMaster.php` の主キー名の変更に伴い、シーダーファイルとの整合性を持たせるため

# 変更結果

- エラーの発生等無し

# 変更内容

- SalesLogsTableSeeder.php

　└配列の要素である`product_id` を`product_master_id` に変更

　└配列の要素に`purchase_time` を追加


- StocksTableSeeder.php

　└配列の要素である`product_id` を`product_master_id` に変更