### PR TITLE
Feature/kataoka/create migration files

### DIFF
--- a/src/database/migrations/2022_02_19_134719_change_image_string_to_long_text_on_product_masters_table.php
+++ b/src/database/migrations/2022_02_19_134719_change_image_string_to_long_text_on_product_masters_table.php
@@ -26,7 +26,7 @@ class ChangeImageStringToLongTextOnProductMastersTable extends Migration
     public function down()
     {
         Schema::table('product_masters', function (Blueprint $table) {
-            $table->string('image')->change();
+            $table->longText('image')->change();
         });
     }
 }

--- a/src/database/migrations/2022_04_23_092855_rename_product_id_to_product_master_id_on_sales_logs_table.php
+++ b/src/database/migrations/2022_04_23_092855_rename_product_id_to_product_master_id_on_sales_logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RenameProductIdToProductMasterIdOnSalesLogsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('sales_logs', function (Blueprint $table) {
+            $table->renameColumn('product_id', 'product_master_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('sales_logs', function (Blueprint $table) {
+            $table->renameColumn('product_master_id', 'product_id');
+        });
+    }
+}


### PR DESCRIPTION
# 変更目的

- rollback実行時に、エラーが発生していたため、修正
- 主キーの名称変更に伴い、整合性を持たせるため、外部キーの名称を変更

# 変更結果

- rollback実行時のエラー発生なし
- migration実行時のエラー発生なし

# 変更内容

- 2022_02_19_134719_change_image_string_to_long_text_on_product_masters_table.php

　└rollback実行時に、文字数オーバーのエラーが出ていたため、修正

- 2022_04_23_092855_rename_product_id_to_product_master_id_on_sales_logs_table.php

　└主キーの名称変更に伴い、カラム名を`product_id` から`product_master_id`へ変更