### PR TITLE
[update]フラッシュメッセージ処理の追記とレイアウト調整

### DIFF
--- a/src/database/seeds/ProductMastersTableSeeder.php
+++ b/src/database/seeds/ProductMastersTableSeeder.php
@@ -33,5 +33,68 @@ class ProductMastersTableSeeder extends Seeder
             'display_order' => 3,
         ];
         DB::table('product_masters')->insert($param);
+        $param = [
+            'product_name' => 'コーラ',
+            'image' => base64_encode(Storage::get('cola.jpg')),
+            'price' => 100,
+            'display_order' => 1,
+        ];
+        DB::table('product_masters')->insert($param);
+        $param = [
+            'product_name' => 'ビール',
+            'image' => base64_encode(Storage::get('beer.jpg')),
+            'price' => 210,
+            'display_order' => 2,
+        ];
+        DB::table('product_masters')->insert($param);
+        $param = [
+            'product_name' => '食パン',
+            'image' => base64_encode(Storage::get('plain_blead.jpg')),
+            'price' => 1900,
+            'display_order' => 3,
+        ];
+        DB::table('product_masters')->insert($param);
+        $param = [
+            'product_name' => 'コーラ',
+            'image' => base64_encode(Storage::get('cola.jpg')),
+            'price' => 100,
+            'display_order' => 1,
+        ];
+        DB::table('product_masters')->insert($param);
+        $param = [
+            'product_name' => 'ビール',
+            'image' => base64_encode(Storage::get('beer.jpg')),
+            'price' => 210,
+            'display_order' => 2,
+        ];
+        DB::table('product_masters')->insert($param);
+        $param = [
+            'product_name' => '食パン',
+            'image' => base64_encode(Storage::get('plain_blead.jpg')),
+            'price' => 1900,
+            'display_order' => 3,
+        ];
+        DB::table('product_masters')->insert($param);
+        $param = [
+            'product_name' => 'コーラ',
+            'image' => base64_encode(Storage::get('cola.jpg')),
+            'price' => 100,
+            'display_order' => 1,
+        ];
+        DB::table('product_masters')->insert($param);
+        $param = [
+            'product_name' => 'ビール',
+            'image' => base64_encode(Storage::get('beer.jpg')),
+            'price' => 210,
+            'display_order' => 2,
+        ];
+        DB::table('product_masters')->insert($param);
+        $param = [
+            'product_name' => '食パン',
+            'image' => base64_encode(Storage::get('plain_blead.jpg')),
+            'price' => 1900,
+            'display_order' => 3,
+        ];
+        DB::table('product_masters')->insert($param);
     }
 }

--- a/src/database/seeds/SalesLogsTableSeeder.php
+++ b/src/database/seeds/SalesLogsTableSeeder.php
@@ -30,5 +30,59 @@ class SalesLogsTableSeeder extends Seeder
             'purchase_time' => Carbon::now(),
         ];
         DB::table('sales_logs')->insert($param);
+        $param = [
+            'product_master_id' => 4,
+            'purchase_price' => 200,
+            'purchase_time' => Carbon::now(),
+        ];
+        DB::table('sales_logs')->insert($param);
+        $param = [
+            'product_master_id' => 5,
+            'purchase_price' => 420,
+            'purchase_time' => Carbon::now(),
+        ];
+        DB::table('sales_logs')->insert($param);
+        $param = [
+            'product_master_id' => 6,
+            'purchase_price' => 3800,
+            'purchase_time' => Carbon::now(),
+        ];
+        DB::table('sales_logs')->insert($param);
+        $param = [
+            'product_master_id' => 7,
+            'purchase_price' => 200,
+            'purchase_time' => Carbon::now(),
+        ];
+        DB::table('sales_logs')->insert($param);
+        $param = [
+            'product_master_id' => 8,
+            'purchase_price' => 420,
+            'purchase_time' => Carbon::now(),
+        ];
+        DB::table('sales_logs')->insert($param);
+        $param = [
+            'product_master_id' => 9,
+            'purchase_price' => 3800,
+            'purchase_time' => Carbon::now(),
+        ];
+        DB::table('sales_logs')->insert($param);
+        $param = [
+            'product_master_id' => 10,
+            'purchase_price' => 200,
+            'purchase_time' => Carbon::now(),
+        ];
+        DB::table('sales_logs')->insert($param);
+        $param = [
+            'product_master_id' => 11,
+            'purchase_price' => 420,
+            'purchase_time' => Carbon::now(),
+        ];
+        DB::table('sales_logs')->insert($param);
+        $param = [
+            'product_master_id' => 12,
+            'purchase_price' => 3800,
+            'purchase_time' => Carbon::now(),
+        ];
+        DB::table('sales_logs')->insert($param);
     }
 }

--- a/src/database/seeds/StocksTableSeeder.php
+++ b/src/database/seeds/StocksTableSeeder.php
@@ -18,11 +18,56 @@ class StocksTableSeeder extends Seeder
         DB::table('stocks')->insert($param);
         $param = [
             'product_master_id' => 2,
-            'stock' => 3,
+            'stock' => 40,
         ];
         DB::table('stocks')->insert($param);
         $param = [
             'product_master_id' => 3,
+            'stock' => 4,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_master_id' => 4,
+            'stock' => 2,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_master_id' => 5,
+            'stock' => 3,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_master_id' => 6,
+            'stock' => 4,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_master_id' => 7,
+            'stock' => 2,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_master_id' => 8,
+            'stock' => 3,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_master_id' => 9,
+            'stock' => 4,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_master_id' => 10,
+            'stock' => 2,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_master_id' => 11,
+            'stock' => 3,
+        ];
+        DB::table('stocks')->insert($param);
+        $param = [
+            'product_master_id' => 12,
             'stock' => 4,
         ];
         DB::table('stocks')->insert($param);

--- a/src/resources/views/index.blade.php
+++ b/src/resources/views/index.blade.php
@@ -8,88 +8,108 @@
 </head>
 <body>
 
-    {{-- フラッシュメッセージ表示エリア --}}
-    @if (session('input_amount_message'))
-        <div class="alert alert-success">
-            {{session('input_amount_message')}}
-        </div>
-    @elseif (session('returned_amount_message'))
-        <div class="alert alert-success">
-            {{session('product_purchase_success_message')}}
-        </div>
-        <div class="alert alert-success">
-            {{session('returned_amount_message')}}
-        </div>
-    @elseif (session('return_of_change'))
-        <div class="alert alert-success">
-            {{session('return_of_change')}}
-        </div>
-    @elseif (session('input_amount_error_message'))
-        <div class="alert alert-danger">
-            {{session('input_amount_error_message')}}
-        </div>
-    @elseif (session('product_purchase_success_message'))
-        <div class="alert alert-success">
-            {{session('product_purchase_success_message')}}
-        </div>
-    @elseif (session('product_purchase_error_message'))
-        <div class="alert alert-danger">
-            {{session('product_purchase_error_message')}}
-        </div>
-    @endif
-    {{-- /フラッシュメッセージ表示エリア --}}
-
-    <div class="mb-5"></div>
-
-    {{-- 金額投入エリア --}}
-    <div class="ml-5">
-        <form action="/" method="post">
-            @csrf
-                <input class="btn btn-secondary" type="submit" name="returned_amount" value="返却">
-                <input class="btn btn-primary" type="submit" name="10yen" value="￥10">
-                <input class="btn btn-primary" type="submit" name="50yen" value="￥50">
-                <input class="btn btn-primary" type="submit" name="100yen" value="￥100">
-                <input class="btn btn-primary" type="submit" name="500yen" value="￥500">
-                <input class="btn btn-primary" type="submit" name="1000yen" value="￥1000">
-                <input class="btn btn-primary" type="submit" name="2000yen" value="￥2000">
-        </form>
+{{-- フラッシュメッセージ表示エリア --}}
+@if (session('input_amount_message'))
+    <div class="alert alert-success">
+        {{session('input_amount_message')}}
     </div>
-    {{-- /金額投入エリア --}}
+@elseif (session('returned_amount_message'))
+    <div class="alert alert-success">
+        {{session('product_purchase_success_message')}}
+    </div>
+    <div class="alert alert-success">
+        {{session('returned_amount_message')}}
+    </div>
+@elseif (session('return_of_change'))
+    <div class="alert alert-success">
+    {{session('return_of_change')}}
+    </div>
+@elseif (session('input_amount_error_message'))
+    <div class="alert alert-danger">    
+    {{session('input_amount_error_message')}}
+    </div>
+@elseif (session('product_purchase_success_message'))
+    <div class="alert alert-success">
+    {{session('product_purchase_success_message')}}
+    </div>
+@elseif (session('product_purchase_error_message'))
+    <div class="alert alert-danger">
+    {{session('product_purchase_error_message')}}
+    </div>
+@endif
+{{-- /フラッシュメッセージ表示エリア --}}
 
-    <div class="mt-5"></div>
-    <div class="ml-5"></div>
-    <div class="ml-5">投入金額:{{ $input_amount }}円</div>
-    <div class="mt-5"></div>
-
-    {{-- 製品購入エリア --}}
-    <div class="ml-5">
-        <div class="row">
-            <div class="card-deck">
-                @foreach($product_masters as $product_master)
-                    <div class="card">
-                        <div class="card-header">{{$product_master->product_name}}</div>
-                        <img src="data:image/jpeg;base64,{{$product_master->image}}" class="card-img-top h-50" alt="">
-                            <div class="card-body">
-                                <p>在庫数:{{$product_master->stocks->stock}}</p>
-                                @if ($product_master->stocks->stock === 0)
-                                    <input class="btn btn-dark" type="submit" value=売切 disabled="disabled">
-                                @else
-                                    <form action="/processProductPurchase"  method="post">
-                                        @csrf
-                                            <input type="hidden" name="id" value="{{$product_master->id}}">
-                                            <input type="hidden" name="product_name" value="{{$product_master->product_name}}">
-                                            <input class="btn btn-primary" type="submit" name="product_price" value="{{$product_master->price}}">
-                                            <input class="btn btn-secondary" type="submit" name="stock+3" value=在庫+3>
-                                            <input type="hidden" name="purchase_time" value="{{ \Carbon\Carbon::now() }}">
-                                    </form>
-                                @endif
+{{-- 自販機エリア --}}
+<div class="container mb-5">
+    <div class="container bg-primary mt-3 pb-3">
+        {{-- 製品購入エリア --}}
+        <div class="row justify-content-center">
+            <div class="col-12">
+                <div class="card-group">
+                        @foreach($product_masters as $product_master)
+                            <div class="col-lg-2">
+                                <div class="card mt-3 mb-3 border-dark">
+                                    <div class="card-header text-center border-dark">{{$product_master->product_name}}
+                                    </div>
+                                    <img src="data:image/jpeg;base64,{{$product_master->image}}" class="card-img-top">
+                                    <div class="card-body border-dark">
+                                    <p>在庫数:{{$product_master->stocks->stock}}</p>
+                                        @if ($product_master->stocks->stock === 0)
+                                            <div class="text-center">
+                                                <input class="btn btn-dark border-dark" type="submit" value=売切 disabled="disabled">
+                                            </div>
+                                        @else
+                                            <form action="/processProductPurchase"  method="post">
+                                                @csrf
+                                                    <input type="hidden" name="id" value="{{$product_master->id}}">
+                                                    <input type="hidden" name="product_name" value="{{$product_master->product_name}}">
+                                                    <div class="text-center">
+                                                        <input class="btn btn-primary border-dark" type="submit" name="product_price" value="{{$product_master->price}}">
+                                                    </div>
+                                                    <input type="hidden" name="purchase_time" value="{{ \Carbon\Carbon::now() }}">
+                                            </form>
+                                        @endif
+                                    </div>
+                                </div>
                             </div>
-                    </div>
-                @endforeach
+                        @endforeach
+                </div>
             </div>
         </div>
-    </div>
-    {{-- /製品購入エリア --}}
+        {{-- /製品購入エリア --}}
+
+        {{-- 金額投入エリア --}}
+        <div class="text-right mr-3">
+            <form action="/" method="post">
+                @csrf
+                    <input class="btn btn-secondary border-dark" type="submit" name="returned_amount" value="返却">
+                    <input class="btn btn-warning border-dark" type="submit" name="10yen" value="￥10">
+                    <input class="btn btn-warning border-dark" type="submit" name="50yen" value="￥50">
+                    <input class="btn btn-warning border-dark" type="submit" name="100yen" value="￥100">
+                    <input class="btn btn-warning border-dark" type="submit" name="500yen" value="￥500">
+                    <input class="btn btn-warning border-dark" type="submit" name="1000yen" value="￥1000">
+                    <input class="btn btn-warning border-dark" type="submit" name="2000yen" value="￥2000">
+            </form>
+        </div>
+        {{-- /金額投入エリア --}}
+
+        {{-- 投入金額表示エリア --}}
+        <div class="clearfix mr-3">
+            <div class="float-right">
+                <div class="input-group-prepend mt-3">
+                    <div class="input-group-prepend">
+                        <div class="input-group-text border-dark">投入金額
+                        </div>
+                    </div>
+                    <input class="rounded border-dark" type="text" value="￥{{ $input_amount }}" readonly>
+                </div>
+            </div>
+        </div>
+        {{-- /投入金額表示エリア --}}
+        
+    </div>  
+</div>
+{{-- /自販機エリア --}}
 
 </body>
 </html>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -14,3 +14,4 @@
 Route::get('/', 'ProductMastersController@index');
 Route::post('/', 'ProductMastersController@processInputAmount');
 Route::post('/processProductPurchase', 'ProductMastersController@processProductPurchase');
+Route::get('processRemainingAmount', 'ProductMastersController@processRemainingAmount');


### PR DESCRIPTION
# 変更目的

- 残金返却と商品購入のフラッシュメッセージを同時に表示するため
- より自販機ライクなレイアウトへ変更するため

# 変更結果

- 想定通りに動作しており、エラーの発生等なし

# 変更内容

- src/app/Http/Controllers/ProductMastersController.php

　└フラッシュメッセージ処理を追記

　└フローチャートに沿った順序へとコードを修正

　└メソッド名を修正

- src/database/seeds/ProductMastersTableSeeder.php

　└画面レイアウトを調整するにあたり、全体のバランスが見たかったため、テストデータを追加

　└テストデータ数:3→12

- src/database/seeds/SalesLogsTableSeeder.php

　└画面レイアウトを調整するにあたり、全体のバランスが見たかったため、テストデータを追加

　└テストデータ数:3→12

- src/database/seeds/StocksTableSeeder.php

　└画面レイアウトを調整するにあたり、全体のバランスが見たかったため、テストデータを追加

　└テストデータ数:3→12

- src/resources/views/index.blade.php

　└投入金額エリアの位置を変更

　└投入金額エリアの表示位置を変更

　└全体のレイアウトを自販機ライクとなるよう調整

- src/routes/web.php

　└コントローラーの処理追記に伴い、ルーティング修正

　└コントローラーのメソッド名変更に伴い、ルーティング修正