### PR TITLE
フォームの二重送信対策を実施

### DIFF
--- a/src/app/Http/Controllers/ProductMastersController.php
+++ b/src/app/Http/Controllers/ProductMastersController.php
@@ -79,6 +79,8 @@ class ProductMastersController extends Controller
             $sales_log->purchase_time = $request->purchase_time;
             $sales_log->save();
             Stock::where('id', $request->id)->decrement('stock');
+            //二重送信防止
+            $request->session()->regenerateToken();
             $request->session()->decrement('input_amount', $request->product_price);
             $message_key = $request->product_name.'を購入しました';
             $request->session()->flash('product_purchase_success_message', $message_key);


### PR DESCRIPTION
# 変更目的

- フォームを二度押しすると、在庫がマイナスになる問題を修正するため
    
![スクリーンショット 2022-06-26 午後1 54 04](https://user-images.githubusercontent.com/79346029/175800311-c9c8708e-0104-4f7c-84dc-7a64aff662c8.jpg)


    

# 変更結果

- フォームを二度押しした際に、エラーページに飛ばすよう修正した

![スクリーンショット 2022-06-26 午後1 58 35（2）](https://user-images.githubusercontent.com/79346029/175800315-8d4260dc-49bb-4902-83aa-23685f6fad3f.jpg)

    

# 変更内容

- ProductMasterController.php

　・processProductPurchaseメソッドに、`$request->session()->regenerateToken();`　を追加し、フォームの二重送信対策を行った