### PR TITLE
商品購入ボタンの表記を変更

### DIFF
--- a/src/app/Http/Controllers/ProductMastersController.php
+++ b/src/app/Http/Controllers/ProductMastersController.php
@@ -79,6 +79,8 @@ class ProductMastersController extends Controller
             $sales_log->purchase_time = $request->purchase_time;
             $sales_log->save();
             Stock::where('id', $request->id)->decrement('stock');
+            //二重送信防止
+            $request->session()->regenerateToken();
             $request->session()->decrement('input_amount', $request->product_price);
             $message_key = $request->product_name.'を購入しました';
             $request->session()->flash('product_purchase_success_message', $message_key);

--- a/src/resources/views/index.blade.php
+++ b/src/resources/views/index.blade.php
@@ -63,9 +63,9 @@
                                                     <input type="hidden" name="product_name" value="{{$product_master->product_name}}">
                                                     <div class="text-center">
                                                         @if ($input_amount >=  $product_master->price)
-                                                            <input class="btn btn-primary border-dark" type="submit" name="product_price" value="{{$product_master->price}}">
+                                                            <input class="btn btn-primary border-dark" type="submit" name="product_price" value="￥{{$product_master->price}}">
                                                         @else
-                                                            <input class="btn btn-primary border-dark" type="submit" name="product_price" value="{{$product_master->price}}" disabled="disabled">
+                                                            <input class="btn btn-primary border-dark" type="submit" name="product_price" value="￥{{$product_master->price}}" disabled="disabled">
                                                         @endif
                                                     </div>
                                                     <input type="hidden" name="purchase_time" value="{{ \Carbon\Carbon::now() }}">


### PR DESCRIPTION
# 変更目的

- 商品購入ボタンに記載されている数値が、金額であることがわかりにくいため修正
    
![スクリーンショット 2022-06-28 午後1 19 15](https://user-images.githubusercontent.com/79346029/176092766-4f7ddfb3-942f-4895-b7fe-4154b8f98a68.jpg)



# 変更結果

- 特にエラーの発生等なし
    
![スクリーンショット 2022-06-28 午後1 19 55](https://user-images.githubusercontent.com/79346029/176092835-42a6fee3-1f8c-4130-bc1e-73cdac99d4ae.jpg)


    

# 変更内容

- index.blade.php

　・商品購入ボタンに”￥”表記を追加し、金額であることがわかりやすいように変更した